### PR TITLE
Add CP-56 documentation to Upcoming Releases

### DIFF
--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -17,11 +17,11 @@ custom_css: releases
 #### Breaking Changes
 *(These are changes to ontologies, classes or properties in the preexisting ontology that make the new release non-backward-compatible.)*
 
-* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-56](https://unifiedcyberontology.atlassian.net/wiki/spaces/OC/pages/1620443156)
+* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* ([*Change Proposal 56*](https://drive.google.com/file/d/1PCjdCGw7wgFnPfbsCn0Fdvdnq9NDW6yA/view))
 
 #### Changes
 
 *(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 
-* Updated CI testing (Makefiles) to reflect repository restructure [CP-56](https://unifiedcyberontology.atlassian.net/wiki/spaces/OC/pages/1620443156)
+* Updated CI testing (Makefiles) to reflect repository restructure ([*Change Proposal 56*](https://drive.google.com/file/d/1PCjdCGw7wgFnPfbsCn0Fdvdnq9NDW6yA/view))
 

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -17,11 +17,11 @@ custom_css: releases
 #### Breaking Changes
 *(These are changes to ontologies, classes or properties in the preexisting ontology that make the new release non-backward-compatible.)*
 
-* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-Ref-Needed]
+* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-56]
 
 #### Changes
 
 *(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 
-* Updated CI testing (Makefiles) to reflect repository restructure [CP-Ref-Needed]
+* Updated CI testing (Makefiles) to reflect repository restructure [CP-56]
 

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -4,23 +4,24 @@ layout: releases
 custom_css: releases
 ---
 
-## {{ page.title }}
+# {{ page.title }}
 
 ###### Date: TBD
 
+## Ontology File(s)
 
-#### Release Notes
+###### GitHub: Release TBD
 
+## Release Notes
 
+#### Breaking Changes
+*(These are changes to ontologies, classes or properties in the preexisting ontology that make the new release non-backward-compatible.)*
 
-#### Change proposals addressed in UCO 0.8.0
+* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-Ref-Needed]
 
+#### Changes
 
+*(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 
-#### Ontology File(s)
-
-
-
-#### Documentation
-
+* Updated CI testing (Makefiles) to reflect repository restructure [CP-Ref-Needed]
 

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -17,11 +17,11 @@ custom_css: releases
 #### Breaking Changes
 *(These are changes to ontologies, classes or properties in the preexisting ontology that make the new release non-backward-compatible.)*
 
-* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-56]
+* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-56](https://unifiedcyberontology.atlassian.net/wiki/spaces/OC/pages/1620443156)
 
 #### Changes
 
 *(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 
-* Updated CI testing (Makefiles) to reflect repository restructure [CP-56]
+* Updated CI testing (Makefiles) to reflect repository restructure [CP-56](https://unifiedcyberontology.atlassian.net/wiki/spaces/OC/pages/1620443156)
 


### PR DESCRIPTION
Adds CP-56 documentation (temporarily pointing towards Confluence until PDFs for UCO are added) to the 0.8.0 upcoming releases page.