### PR TITLE
Documentation covering CPs 56, 80, 82, 84

### DIFF
--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -17,11 +17,11 @@ custom_css: releases
 #### Breaking Changes
 *(These are changes to ontologies, classes or properties in the preexisting ontology that make the new release non-backward-compatible.)*
 
-* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-56](https://unifiedcyberontology.atlassian.net/wiki/spaces/OC/pages/1620443156)
+* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* ([*Change Proposal 56*](https://drive.google.com/file/d/1PCjdCGw7wgFnPfbsCn0Fdvdnq9NDW6yA/view))
 
 #### Changes
 
 *(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 
-* Updated CI testing (Makefiles) to reflect repository restructure [CP-56](https://unifiedcyberontology.atlassian.net/wiki/spaces/OC/pages/1620443156)
+* Updated CI testing (Makefiles) to reflect repository restructure ([*Change Proposal 56*](https://drive.google.com/file/d/1PCjdCGw7wgFnPfbsCn0Fdvdnq9NDW6yA/view))
 

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -25,4 +25,4 @@ custom_css: releases
 * Updated CI testing (Makefiles) to reflect repository restructure ([*Change Proposal 56*](https://drive.google.com/file/d/1PCjdCGw7wgFnPfbsCn0Fdvdnq9NDW6yA/view))
 * Normalized all decimal number properties in the ontology to xsd:decimal ([*Change Proposal 80*](https://drive.google.com/file/d/1NKwEehcRDWh9zk9QOENckd7njYWxgVE4/view))
 * Add vocabulary namespace to uco.ttl in uco-master ([*Change Proposal 82*](https://drive.google.com/file/d/1qQibtD9QAqciLOBkkk6WdDcrz7nEQZL2/view))
-
+* Fix namespace prefix for WhoisContactTypeVocab from observable to vocabulary ([*Change Proposal 84*](https://drive.google.com/file/d/1KbYImZyxzL3kPfA9-SP4Xi_pXnEkOw0W/view))

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -23,4 +23,5 @@ custom_css: releases
 *(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 
 * Updated CI testing (Makefiles) to reflect repository restructure ([*Change Proposal 56*](https://drive.google.com/file/d/1PCjdCGw7wgFnPfbsCn0Fdvdnq9NDW6yA/view))
+* Normalized all decimal number properties in the ontology to xsd:decimal ([*Change Proposal 80*](https://drive.google.com/file/d/1NKwEehcRDWh9zk9QOENckd7njYWxgVE4/view))
 

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -17,11 +17,11 @@ custom_css: releases
 #### Breaking Changes
 *(These are changes to ontologies, classes or properties in the preexisting ontology that make the new release non-backward-compatible.)*
 
-* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-Ref-Needed]
+* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-56]
 
 #### Changes
 
 *(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 
-* Updated CI testing (Makefiles) to reflect repository restructure [CP-Ref-Needed]
+* Updated CI testing (Makefiles) to reflect repository restructure [CP-56]
 

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -24,4 +24,5 @@ custom_css: releases
 
 * Updated CI testing (Makefiles) to reflect repository restructure ([*Change Proposal 56*](https://drive.google.com/file/d/1PCjdCGw7wgFnPfbsCn0Fdvdnq9NDW6yA/view))
 * Normalized all decimal number properties in the ontology to xsd:decimal ([*Change Proposal 80*](https://drive.google.com/file/d/1NKwEehcRDWh9zk9QOENckd7njYWxgVE4/view))
+* Add vocabulary namespace to uco.ttl in uco-master ([*Change Proposal 82*](https://drive.google.com/file/d/1qQibtD9QAqciLOBkkk6WdDcrz7nEQZL2/view))
 

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -4,23 +4,24 @@ layout: releases
 custom_css: releases
 ---
 
-## {{ page.title }}
+# {{ page.title }}
 
 ###### Date: TBD
 
+## Ontology File(s)
 
-#### Release Notes
+###### GitHub: Release TBD
 
+## Release Notes
 
+#### Breaking Changes
+*(These are changes to ontologies, classes or properties in the preexisting ontology that make the new release non-backward-compatible.)*
 
-#### Change proposals addressed in UCO 0.8.0
+* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-Ref-Needed]
 
+#### Changes
 
+*(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 
-#### Ontology File(s)
-
-
-
-#### Documentation
-
+* Updated CI testing (Makefiles) to reflect repository restructure [CP-Ref-Needed]
 

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -17,11 +17,11 @@ custom_css: releases
 #### Breaking Changes
 *(These are changes to ontologies, classes or properties in the preexisting ontology that make the new release non-backward-compatible.)*
 
-* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-56]
+* Restructured repository by moving previously prefixed uco-* ontology files under new directory /ontology/* [CP-56](https://unifiedcyberontology.atlassian.net/wiki/spaces/OC/pages/1620443156)
 
 #### Changes
 
 *(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 
-* Updated CI testing (Makefiles) to reflect repository restructure [CP-56]
+* Updated CI testing (Makefiles) to reflect repository restructure [CP-56](https://unifiedcyberontology.atlassian.net/wiki/spaces/OC/pages/1620443156)
 

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -4,23 +4,20 @@ layout: releases
 custom_css: releases
 ---
 
-## {{ page.title }}
+# {{ page.title }}
 
 ###### Date: TBD
 
+## Ontology File(s)
 
-#### Release Notes
+###### GitHub: Release TBD
 
+## Release Notes
 
-
-#### Change proposals addressed in UCO 0.8.0
-
-
-
-#### Ontology File(s)
+#### Breaking Changes
+*(These are changes to ontologies, classes or properties in the preexisting ontology that make the new release non-backward-compatible.)*
 
 
-
-#### Documentation
-
+#### Changes
+*(These are general changes to the preexisting ontology that are not breaking or range changes.)*
 


### PR DESCRIPTION
This PR will add documentation to the 'Under Development' page for the eventual 0.8.0 release for UCO.

It adds documents and references PDFs for each CP of the following:
- FastTrack-CP-56
- FastTrack-CP-80
- BugFix-CP-82
- BugFix-CP-84